### PR TITLE
update ci_scheduled.yml to accept optional inputs

### DIFF
--- a/.github/workflows/ci_scheduled.yml
+++ b/.github/workflows/ci_scheduled.yml
@@ -49,9 +49,6 @@ jobs:
           echo $CASJOBS_USERID
           echo $CASJOBS_PW
           jupyter nbconvert --template classic --to html --execute "${{ matrix.notebooks }}"
-          env:
-            CASJOBS_PW: ${{ secrets.CASJOBS_PW }}
-            CASJOBS_USERID: ${{ secrets.CASJOBS_USERID }}
       - name: Validate notebooks
         run: | 
           pytest --nbval "${{ matrix.notebooks }}"

--- a/.github/workflows/ci_scheduled.yml
+++ b/.github/workflows/ci_scheduled.yml
@@ -58,5 +58,10 @@ jobs:
           echo $CASJOBS_PW
           jupyter nbconvert --template classic --to html --execute "${{ matrix.notebooks }}"
       - name: Validate notebooks
-        run: | 
+        env:
+          CASJOBS_PW: ${{ secrets.CASJOBS_PW }}
+          CASJOBS_USERID: ${{ secrets.CASJOBS_USERID }}
+        run: |
+          echo $CASJOBS_USERID
+          echo $CASJOBS_PW
           pytest --nbval "${{ matrix.notebooks }}"

--- a/.github/workflows/ci_scheduled.yml
+++ b/.github/workflows/ci_scheduled.yml
@@ -6,9 +6,9 @@ on:
           description: 'CASJOBS user ID'
         CASJOBS_PW:
           description: 'CASJOBS password'
-# env:
-#   CASJOBS_PW: ${{ secrets.CASJOBS_PW }}
-#   CASJOBS_USERID: ${{ secrets.CASJOBS_USERID }}
+env:
+  CASJOBS_PW: ${{ secrets.CASJOBS_PW }}
+  CASJOBS_USERID: ${{ secrets.CASJOBS_USERID }}
   
 permissions: write-all  
 jobs:
@@ -50,16 +50,16 @@ jobs:
           pip install nbconvert
           
       - name: Execute notebooks
-        env:
-          CASJOBS_PW: ${{ secrets.CASJOBS_PW }}
-          CASJOBS_USERID: ${{ secrets.CASJOBS_USERID }}
+#         env:
+#           CASJOBS_PW: ${{ secrets.CASJOBS_PW }}
+#           CASJOBS_USERID: ${{ secrets.CASJOBS_USERID }}
         run: |
           echo $CASJOBS_USERID
           echo $CASJOBS_PW
           jupyter nbconvert --template classic --to html --execute "${{ matrix.notebooks }}"
       - name: Validate notebooks
-        env:
-          CASJOBS_PW: ${{ secrets.CASJOBS_PW }}
-          CASJOBS_USERID: ${{ secrets.CASJOBS_USERID }}
+#         env:
+#           CASJOBS_PW: ${{ secrets.CASJOBS_PW }}
+#           CASJOBS_USERID: ${{ secrets.CASJOBS_USERID }}
         run: |
           pytest --nbval "${{ matrix.notebooks }}"

--- a/.github/workflows/ci_scheduled.yml
+++ b/.github/workflows/ci_scheduled.yml
@@ -1,11 +1,11 @@
 name: Scheduled Notebook Execution
 on:
   workflow_call:
-      secrets:
-        CASJOBS_USERID:
-          description: 'CASJOBS user ID'
-        CASJOBS_PW:
-          description: 'CASJOBS password'
+#       secrets:
+#         CASJOBS_USERID:
+#           description: 'CASJOBS user ID'
+#         CASJOBS_PW:
+#           description: 'CASJOBS password'
 env:
   CASJOBS_PW: ${{ secrets.CASJOBS_PW }}
   CASJOBS_USERID: ${{ secrets.CASJOBS_USERID }}

--- a/.github/workflows/ci_scheduled.yml
+++ b/.github/workflows/ci_scheduled.yml
@@ -18,7 +18,6 @@ jobs:
   scheduled-notebook-execution:
     needs: gather-notebooks
     runs-on: ubuntu-latest
-    secrets: inherit
     strategy:
         fail-fast: false
         matrix:

--- a/.github/workflows/ci_scheduled.yml
+++ b/.github/workflows/ci_scheduled.yml
@@ -49,6 +49,9 @@ jobs:
           echo $CASJOBS_USERID
           echo $CASJOBS_PW
           jupyter nbconvert --template classic --to html --execute "${{ matrix.notebooks }}"
+          env:
+            CASJOBS_PW: ${{ secrets.CASJOBS_PW }}
+            CASJOBS_USERID: ${{ secrets.CASJOBS_USERID }}
       - name: Validate notebooks
         run: | 
           pytest --nbval "${{ matrix.notebooks }}"

--- a/.github/workflows/ci_scheduled.yml
+++ b/.github/workflows/ci_scheduled.yml
@@ -1,9 +1,9 @@
 name: Scheduled Notebook Execution
 on:
   workflow_call:
-env:
-  CASJOBS_PW: ${{ secrets.CASJOBS_PW }}
-  CASJOBS_USERID: ${{ secrets.CASJOBS_USERID }}
+# env:
+#   CASJOBS_PW: ${{ secrets.CASJOBS_PW }}
+#   CASJOBS_USERID: ${{ secrets.CASJOBS_USERID }}
   
 permissions: write-all  
 jobs:
@@ -45,6 +45,9 @@ jobs:
           pip install nbconvert
           
       - name: Execute notebooks
+        env:
+          CASJOBS_PW: ${{ secrets.CASJOBS_PW }}
+          CASJOBS_USERID: ${{ secrets.CASJOBS_USERID }}
         run: |
           echo $CASJOBS_USERID
           echo $CASJOBS_PW

--- a/.github/workflows/ci_scheduled.yml
+++ b/.github/workflows/ci_scheduled.yml
@@ -18,6 +18,7 @@ jobs:
   scheduled-notebook-execution:
     needs: gather-notebooks
     runs-on: ubuntu-latest
+    secrets: inherit
     strategy:
         fail-fast: false
         matrix:

--- a/.github/workflows/ci_scheduled.yml
+++ b/.github/workflows/ci_scheduled.yml
@@ -1,11 +1,11 @@
 name: Scheduled Notebook Execution
 on:
   workflow_call:
-#       secrets:
-#         CASJOBS_USERID:
-#           description: 'CASJOBS user ID'
-#         CASJOBS_PW:
-#           description: 'CASJOBS password'
+      secrets:
+        CASJOBS_USERID:
+          description: 'CASJOBS user ID'
+        CASJOBS_PW:
+          description: 'CASJOBS password'
 env:
   CASJOBS_PW: ${{ secrets.CASJOBS_PW }}
   CASJOBS_USERID: ${{ secrets.CASJOBS_USERID }}
@@ -50,16 +50,10 @@ jobs:
           pip install nbconvert
           
       - name: Execute notebooks
-#         env:
-#           CASJOBS_PW: ${{ secrets.CASJOBS_PW }}
-#           CASJOBS_USERID: ${{ secrets.CASJOBS_USERID }}
         run: |
           echo $CASJOBS_USERID
           echo $CASJOBS_PW
           jupyter nbconvert --template classic --to html --execute "${{ matrix.notebooks }}"
       - name: Validate notebooks
-#         env:
-#           CASJOBS_PW: ${{ secrets.CASJOBS_PW }}
-#           CASJOBS_USERID: ${{ secrets.CASJOBS_USERID }}
         run: |
           pytest --nbval "${{ matrix.notebooks }}"

--- a/.github/workflows/ci_scheduled.yml
+++ b/.github/workflows/ci_scheduled.yml
@@ -51,8 +51,6 @@ jobs:
           
       - name: Execute notebooks
         run: |
-          echo $CASJOBS_USERID
-          echo $CASJOBS_PW
           jupyter nbconvert --template classic --to html --execute "${{ matrix.notebooks }}"
       - name: Validate notebooks
         run: |

--- a/.github/workflows/ci_scheduled.yml
+++ b/.github/workflows/ci_scheduled.yml
@@ -1,6 +1,11 @@
 name: Scheduled Notebook Execution
 on:
   workflow_call:
+      secrets:
+        CASJOBS_USERID:
+          description: 'CASJOBS user ID'
+        CASJOBS_PW:
+          description: 'CASJOBS password'
 # env:
 #   CASJOBS_PW: ${{ secrets.CASJOBS_PW }}
 #   CASJOBS_USERID: ${{ secrets.CASJOBS_USERID }}

--- a/.github/workflows/ci_scheduled.yml
+++ b/.github/workflows/ci_scheduled.yml
@@ -50,7 +50,6 @@ jobs:
           pip install pytest
           pip install nbval
           pip install nbconvert
-          
       - name: Execute notebooks
         run: |
           jupyter nbconvert --template classic --to html --execute "${{ matrix.notebooks }}"

--- a/.github/workflows/ci_scheduled.yml
+++ b/.github/workflows/ci_scheduled.yml
@@ -4,8 +4,10 @@ on:
       secrets:
         CASJOBS_USERID:
           description: 'CASJOBS user ID'
+          required: false
         CASJOBS_PW:
           description: 'CASJOBS password'
+          required: false
 env:
   CASJOBS_PW: ${{ secrets.CASJOBS_PW }}
   CASJOBS_USERID: ${{ secrets.CASJOBS_USERID }}

--- a/.github/workflows/ci_scheduled.yml
+++ b/.github/workflows/ci_scheduled.yml
@@ -62,6 +62,4 @@ jobs:
           CASJOBS_PW: ${{ secrets.CASJOBS_PW }}
           CASJOBS_USERID: ${{ secrets.CASJOBS_USERID }}
         run: |
-          echo $CASJOBS_USERID
-          echo $CASJOBS_PW
           pytest --nbval "${{ matrix.notebooks }}"

--- a/.github/workflows/ci_scheduled.yml
+++ b/.github/workflows/ci_scheduled.yml
@@ -46,6 +46,8 @@ jobs:
           
       - name: Execute notebooks
         run: |
+          echo $CASJOBS_USERID
+          echo $CASJOBS_PW
           jupyter nbconvert --template classic --to html --execute "${{ matrix.notebooks }}"
       - name: Validate notebooks
         run: | 


### PR DESCRIPTION
**Relevant Tickets and PRs**
- [SPB-1322](https://jira.stsci.edu/browse/SPB-1322)
- [mast_notebooks PR #25](https://github.com/spacetelescope/mast_notebooks/pull/25)

**High-Level Summary**
- Several notebooks in mast_notebooks require CASJOBS username and password information (stored as github secrets)
- This login information wasn't making it into the _Execute notebooks_ and _Validate notebooks_ steps in ci_scheduled.yml
- This PR adds optional inputs so that the CASJOBS login info can be passed into ci_scheduled.yml by workflow(s) in mast_notebooks.