### PR TITLE
Updated various workflows used by mast_notebooks workflows to accept optional inputs

### DIFF
--- a/.github/workflows/ci_builder.yml
+++ b/.github/workflows/ci_builder.yml
@@ -1,5 +1,15 @@
 on:
   workflow_call:
+      secrets:
+        CASJOBS_USERID:
+          description: 'CASJOBS user ID'
+          required: false
+        CASJOBS_PW:
+          description: 'CASJOBS password'
+          required: false
+env:
+  CASJOBS_PW: ${{ secrets.CASJOBS_PW }}
+  CASJOBS_USERID: ${{ secrets.CASJOBS_USERID }}
  
 jobs:
   deploy-book:

--- a/.github/workflows/ci_builder_manual.yml
+++ b/.github/workflows/ci_builder_manual.yml
@@ -1,5 +1,15 @@
 on:
   workflow_call:
+      secrets:
+        CASJOBS_USERID:
+          description: 'CASJOBS user ID'
+          required: false
+        CASJOBS_PW:
+          description: 'CASJOBS password'
+          required: false
+env:
+  CASJOBS_PW: ${{ secrets.CASJOBS_PW }}
+  CASJOBS_USERID: ${{ secrets.CASJOBS_USERID }}
  
 jobs:
   deploy-book:

--- a/.github/workflows/ci_runner.yml
+++ b/.github/workflows/ci_runner.yml
@@ -7,7 +7,9 @@ on:
         CASJOBS_PW:
           description: 'CASJOBS password'
           required: false
-  
+env:
+  CASJOBS_PW: ${{ secrets.CASJOBS_PW }}
+  CASJOBS_USERID: ${{ secrets.CASJOBS_USERID }}
 jobs:
   gather-notebooks:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci_runner.yml
+++ b/.github/workflows/ci_runner.yml
@@ -7,10 +7,10 @@ on:
         CASJOBS_PW:
           description: 'CASJOBS password'
           required: false
-
 env:
   CASJOBS_PW: ${{ secrets.CASJOBS_PW }}
   CASJOBS_USERID: ${{ secrets.CASJOBS_USERID }}
+  
 jobs:
   gather-notebooks:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci_runner.yml
+++ b/.github/workflows/ci_runner.yml
@@ -7,6 +7,7 @@ on:
         CASJOBS_PW:
           description: 'CASJOBS password'
           required: false
+
 env:
   CASJOBS_PW: ${{ secrets.CASJOBS_PW }}
   CASJOBS_USERID: ${{ secrets.CASJOBS_USERID }}

--- a/.github/workflows/ci_runner.yml
+++ b/.github/workflows/ci_runner.yml
@@ -1,5 +1,12 @@
 on:
   workflow_call:
+      secrets:
+        CASJOBS_USERID:
+          description: 'CASJOBS user ID'
+          required: false
+        CASJOBS_PW:
+          description: 'CASJOBS password'
+          required: false
   
 jobs:
   gather-notebooks:


### PR DESCRIPTION
**Relevant Tickets and PRs**

- [SPB-1322](https://jira.stsci.edu/browse/SPB-1322)
- [notebook-ci-actions PR #1](https://github.com/spacetelescope/notebook-ci-actions/pull/1) 
- [mast_notebooks PR #25](https://github.com/spacetelescope/mast_notebooks/pull/25)

**High-Level Summary**
- Further analysis on [mast_notebooks PR #25](https://github.com/spacetelescope/mast_notebooks/pull/25) suggests that several other workflows most likely will fail in the same way that ci_scheduled.yml was failing. 
- To remedy this, CASJOBS login info stored in secrets will be passed in to the following as an optional input:
  - ci_builder.yml
  - ci_builder_manual.yml
  - ci_runner.yml