### PR TITLE
Add support for pre-requirements.txt

### DIFF
--- a/.github/workflows/ci_runner.yml
+++ b/.github/workflows/ci_runner.yml
@@ -64,6 +64,9 @@ jobs:
             chmod +x $(dirname "${{ matrix.notebooks }}")/pre-requirements.sh
             ./$(dirname "${{ matrix.notebooks }}")/pre-requirements.sh
           fi
+          if [ -f $(dirname "${{ matrix.notebooks }}")/pre-requirements.txt ]; then
+            pip install -r $(dirname "${{ matrix.notebooks }}")/pre-requirements.txt
+          fi          
           #pip install -r $(dirname "${{ matrix.notebooks }}")/requirements.txt
           pip install -r $(dirname ${{ matrix.notebooks }})/requirements.txt
           pip install pytest


### PR DESCRIPTION
Added support for the `pre-requirements.txt` in GitHub Actions workflow. Several notebooks in the jdat-notebooks repository have their individual `pre-requirements.txt` files. This ensures them to be installed before running the requirements.txt