### PR TITLE
Added workflow to find broken links in notebook html pages on github.io

### DIFF
--- a/.github/workflows/broken_link_checker.yml
+++ b/.github/workflows/broken_link_checker.yml
@@ -1,7 +1,7 @@
 # This workflow checks notebook html pages deployed to github.io for broken links.
 
 on:
-  workflow_call:
+  workflow_dispatch:
 
 jobs:
   broken_link_checker_job:

--- a/.github/workflows/broken_link_checker.yml
+++ b/.github/workflows/broken_link_checker.yml
@@ -1,0 +1,15 @@
+# This workflow checks notebook html pages deployed to github.io for broken links.
+
+on:
+  workflow_call:
+
+jobs:
+  broken_link_checker_job:
+    runs-on: ubuntu-latest
+    name: Check for broken links
+    steps:
+      - name: Check for broken links
+        id: link-report
+        uses: elliotforbes/broken-link-checker@1.0.3
+        with:
+          url: 'https://spacetelescope.github.io/hst_notebooks/'

--- a/.github/workflows/broken_link_checker.yml
+++ b/.github/workflows/broken_link_checker.yml
@@ -1,15 +1,33 @@
-# This workflow checks notebook html pages deployed to github.io for broken links.
+# This workflow checks notebook html pages deployed to github.io for broken links. If broken links are found, the
+# workflow will fail and report a list of the broken links and the pages that contain them.
+#
+# Inputs
+# website_url : string, optional.
+#   The URL of the website to check. If not specified, the default value is
+#   'https://spacetelescope.github.io/<your repository name here>'. NOTE: In some cases,the default value for
+#   website_url may not result in the workflow search for brokenlinks ONLY on that page. The solution is to explicitly
+#   specifying the full url of the repository's starting page
+#   (e.g. https://spacetelescope.github.io/<your repository name here>/intro.html').
 
 on:
-  workflow_dispatch:
+  workflow_call:
+    inputs:
+      website_url:
+        default: https://spacetelescope.github.io/${{ github.event.repository.name }}
+        description: "The URL of the website to check."
+        required: false
+        type: 'string'
 
 jobs:
-  broken_link_checker_job:
+  find_broken_links:
     runs-on: ubuntu-latest
-    name: Check for broken links
+    name: Evaluation of ${{ inputs.website_url }} for broken links
     steps:
-      - name: Check for broken links
-        id: link-report
-        uses: elliotforbes/broken-link-checker@1.0.3
+      - name: Broken-Links-Crawler
+        uses: ScholliYT/Broken-Links-Crawler-Action@v3.3.0
         with:
-          url: 'https://spacetelescope.github.io/hst_notebooks/'
+          website_url: ${{ inputs.website_url }}
+          resolve_before_filtering: 'true'
+          verbose: 'Error'
+          max_retry_time: 30
+          max_retries: 5


### PR DESCRIPTION
**Relevant Tickets**
- [SPB-1732](https://jira.stsci.edu/browse/SPB-1732)
- [SPB-1733](https://jira.stsci.edu/browse/SPB-1733)

**Summary**
- Ticket [SPB-1732 ](https://jira.stsci.edu/browse/SPB-1733)revealed a lurking problem. We had no way to identify dead links in the notebook HTML pages on github.io. 
- To remedy this issue, this PR adds new a reusable workflow that can be used to regularly scan deployed notebook HTML pages for broken links and inform the team when they are found.