### PR TITLE
Enhance Notebook HTML Conversion with Selective Cell Hiding

### DIFF
--- a/.github/workflows/ci_nightly.yml
+++ b/.github/workflows/ci_nightly.yml
@@ -48,7 +48,7 @@ jobs:
           pip install nbconvert
       - name: Execute notebooks
         run: |
-          jupyter nbconvert --template classic --to html --execute "${{ matrix.notebooks }}"
+          jupyter nbconvert --to html --TagRemovePreprocessor.enabled=True --TagRemovePreprocessor.remove_input_tags='["hide-cell"]' --execute "${{ matrix.notebooks }}"
       #- name: Validate notebooks 
       #  run: |
       #   pytest --nbval "${{ matrix.notebooks }}"

--- a/.github/workflows/ci_runner.yml
+++ b/.github/workflows/ci_runner.yml
@@ -83,7 +83,7 @@ jobs:
         run: |
           export CASJOBS_PW="$CI_CASJOBS_PW"
           export CASJOBS_USERID="$CI_CASJOBS_USERID"
-          jupyter nbconvert --template classic --to html --execute "${{ matrix.notebooks }}"
+          jupyter nbconvert --to html --TagRemovePreprocessor.enabled=True --TagRemovePreprocessor.remove_input_tags='["hide-cell"]' --execute "${{ matrix.notebooks }}"
       - name: Validate notebooks 
         run: |
          pytest --nbval "${{ matrix.notebooks }}" 

--- a/.github/workflows/ci_scheduled.yml
+++ b/.github/workflows/ci_scheduled.yml
@@ -59,7 +59,7 @@ jobs:
           pip install nbconvert
       - name: Execute notebooks
         run: |
-          jupyter nbconvert --template classic --to html --execute "${{ matrix.notebooks }}"
+          jupyter nbconvert --to html --TagRemovePreprocessor.enabled=True --TagRemovePreprocessor.remove_input_tags='["hide-cell"]' --execute "${{ matrix.notebooks }}"
       - name: Validate notebooks
         run: |
           pytest --nbval "${{ matrix.notebooks }}"

--- a/.github/workflows/ci_validation.yml
+++ b/.github/workflows/ci_validation.yml
@@ -80,7 +80,7 @@ jobs:
         for file in ${{ steps.changed-files.outputs.all_changed_files }}; do
           echo "$file was updated, executing notebook"
           run: | 
-            jupyter nbconvert --template classic --to html --execute $file
+            jupyter nbconvert --to html --TagRemovePreprocessor.enabled=True --TagRemovePreprocessor.remove_input_tags='["hide-cell"]' --execute $file
         done
         
 #    - name: Execute notebooks


### PR DESCRIPTION
**Summary**

This PR updates our notebook-to-HTML conversion process to selectively hide cells, primarily focusing on markdown cells containing developer notes. By leveraging the "hide-cell" tag, we gain the flexibility to exclude any cell from the HTML output.

Changes

Modified the `nbconvert` command in the GitHub Actions workflow to incorporate `TagRemovePreprocessor`.
Introduced the ability to use the "hide-cell" tag for selectively hiding cells in the HTML output.

The main goal is to hide markdown cells with developer notes, which are not intended for the final audience.
While the primary use is for developer notes, this feature provides the flexibility to hide any cell in a notebook, including code or output cells, by using the "hide-cell" tag.

Tag markdown cells containing developer notes, or any other cells you wish to hide, with "hide-cell" in Jupyter notebooks.
This tagging will ensure these cells are excluded from the HTML conversion, making the published content cleaner and more focused.
**Testing and Implementation**
<img width="1651" alt="image" src="https://github.com/spacetelescope/notebook-ci-actions/assets/66814693/0ef08cb5-59f1-40a2-aec1-d37d1c09f6c4">


This update affects only the HTML conversion process; the original .ipynb files remain unaltered.
