### PR TITLE
Enhance notebook HTML conversion with selective cell hiding

### DIFF
--- a/.github/workflows/ci_build_merge_manual.yml
+++ b/.github/workflows/ci_build_merge_manual.yml
@@ -83,7 +83,7 @@ jobs:
         export PYDEVD_DISABLE_FILE_VALIDATION=1
         export SKLEARN_ALLOW_DEPRECATED_SKLEARN_PACKAGE_INSTALL=True
         if [ "${{ matrix.notebook }}" != "notebooks/preimaging/preimaging_01_mirage.ipynb" ]; then
-          if ! jupyter nbconvert --to notebook --execute --inplace ${{ matrix.notebook }}; then
+          if ! jupyter nbconvert --to notebook --execute --inplace --TagRemovePreprocessor.enabled=True --TagRemovePreprocessor.remove_input_tags='["hide-cell"]' ${{ matrix.notebook }}; then
             python .github/scripts/insert_failure_message.py ${{ matrix.notebook }}
           fi
         fi

--- a/.github/workflows/ci_build_merge_manual_single.yml
+++ b/.github/workflows/ci_build_merge_manual_single.yml
@@ -86,7 +86,7 @@ jobs:
         export PYDEVD_DISABLE_FILE_VALIDATION=1
         export SKLEARN_ALLOW_DEPRECATED_SKLEARN_PACKAGE_INSTALL=True
         if [ "${{ matrix.notebook }}" != "notebooks/preimaging/preimaging_01_mirage.ipynb" ]; then
-          if ! jupyter nbconvert --to notebook --execute --inplace ${{ matrix.notebook }}; then
+          if ! jupyter nbconvert --to notebook --execute --inplace --TagRemovePreprocessor.enabled=True --TagRemovePreprocessor.remove_input_tags='["hide-cell"]' ${{ matrix.notebook }}; then
             python .github/scripts/insert_failure_message.py ${{ matrix.notebook }}
           fi
         fi

--- a/.github/workflows/ci_nightly.yml
+++ b/.github/workflows/ci_nightly.yml
@@ -48,7 +48,7 @@ jobs:
           pip install nbconvert
       - name: Execute notebooks
         run: |
-          jupyter nbconvert --template classic --to html --execute "${{ matrix.notebooks }}"
+          jupyter nbconvert --template classic --to html --TagRemovePreprocessor.enabled=True --TagRemovePreprocessor.remove_input_tags='["hide-cell"]' --execute "${{ matrix.notebooks }}"
       #- name: Validate notebooks 
       #  run: |
       #   pytest --nbval "${{ matrix.notebooks }}"

--- a/.github/workflows/ci_runner.yml
+++ b/.github/workflows/ci_runner.yml
@@ -104,7 +104,7 @@ jobs:
         run: |
           #export CASJOBS_PW="$CI_CASJOBS_PW"
           #export CASJOBS_USERID="$CI_CASJOBS_USERID"
-          if ! jupyter nbconvert --to notebook --execute --inplace ${{ matrix.notebooks }}; then
+          if ! jupyter nbconvert --to notebook --execute --inplace --TagRemovePreprocessor.enabled=True --TagRemovePreprocessor.remove_input_tags='["hide-cell"]' ${{ matrix.notebooks }}; then
             python .github/scripts/insert_failure_message.py ${{ matrix.notebooks }}
           fi
           

--- a/.github/workflows/ci_scheduled.yml
+++ b/.github/workflows/ci_scheduled.yml
@@ -76,7 +76,7 @@ jobs:
           
       - name: Execute notebooks
         run: |
-          jupyter nbconvert --template classic --to html --execute "${{ matrix.notebooks }}"
+          jupyter nbconvert --template classic --to html --TagRemovePreprocessor.enabled=True --TagRemovePreprocessor.remove_input_tags='["hide-cell"]' --execute "${{ matrix.notebooks }}"
       - name: Validate notebooks
         run: |
           pytest --nbval "${{ matrix.notebooks }}"

--- a/.github/workflows/ci_validation.yml
+++ b/.github/workflows/ci_validation.yml
@@ -80,7 +80,7 @@ jobs:
         for file in ${{ steps.changed-files.outputs.all_changed_files }}; do
           echo "$file was updated, executing notebook"
           run: | 
-            jupyter nbconvert --template classic --to html --execute $file
+            jupyter nbconvert --template classic --to html --TagRemovePreprocessor.enabled=True --TagRemovePreprocessor.remove_input_tags='["hide-cell"]' --execute $file
         done
         
 #    - name: Execute notebooks

--- a/.github/workflows/py-matrix.yml
+++ b/.github/workflows/py-matrix.yml
@@ -66,7 +66,7 @@ jobs:
           pip install nbconvert
       - name: Execute notebooks
         run: |
-          jupyter nbconvert --template classic --to html --execute "${{ matrix.notebooks }}"
+          jupyter nbconvert --template classic --to html --TagRemovePreprocessor.enabled=True --TagRemovePreprocessor.remove_input_tags='["hide-cell"]' --execute "${{ matrix.notebooks }}"
       - name: Validate notebooks
         run: |
           pytest --nbval "${{ matrix.notebooks }}"


### PR DESCRIPTION
**Summary**

This PR updates our notebook-to-HTML conversion process to selectively hide cells, primarily focusing on markdown cells containing developer notes. By leveraging the "hide-cell" tag, we gain the flexibility to exclude any cell from the HTML output.

Changes

Modified the `nbconvert` command in the GitHub Actions workflow to incorporate `TagRemovePreprocessor`.
Introduced the ability to use the "hide-cell" tag for selectively hiding cells in the HTML output.

The main goal is to hide markdown cells with developer notes, which are not intended for the final audience.
While the primary use is for developer notes, this feature provides the flexibility to hide any cell in a notebook, including code or output cells, by using the "hide-cell" tag.

Tag markdown cells containing developer notes, or any other cells you wish to hide, with "hide-cell" in Jupyter notebooks.
This tagging will ensure these cells are excluded from the HTML conversion, making the published content cleaner and more focused.
**Testing and Implementation**
<img width="1651" alt="image" src="https://github.com/spacetelescope/notebook-ci-actions/assets/66814693/0ef08cb5-59f1-40a2-aec1-d37d1c09f6c4">


This update affects only the HTML conversion process; the original .ipynb files remain unaltered.
