### PR TITLE
Updated version of changed-files used from v26.1 to v41.0.1 in several workflows

### DIFF
--- a/.github/workflows/ci_runner.yml
+++ b/.github/workflows/ci_runner.yml
@@ -21,7 +21,7 @@ jobs:
     ## routine to gather only the changed notebook files and supply them to the matrix
     - name: changed-files
       id: get-changed-files
-      uses: tj-actions/changed-files@v26.1
+      uses: tj-actions/changed-files@v41.0.1
       with:
         separator: ","
         files: |

--- a/.github/workflows/ci_validation.yml
+++ b/.github/workflows/ci_validation.yml
@@ -55,7 +55,7 @@ jobs:
       
     - name: Gather changed notebooks
       id: changed-files
-      uses: tj-actions/changed-files@v26.1
+      uses: tj-actions/changed-files@v41.0.1
       with:
         files: |
           **/*.ipynb

--- a/.github/workflows/notebook_pep8check.yml
+++ b/.github/workflows/notebook_pep8check.yml
@@ -16,7 +16,7 @@ jobs:
     ## routine to gather only the changed notebook files and supply them to the matrix
     - name: changed-files
       id: get-changed-files
-      uses: tj-actions/changed-files@v26.1
+      uses: tj-actions/changed-files@v41.0.1
       with:
         separator: ","
         files: |

--- a/.github/workflows/script_pep8check.yml
+++ b/.github/workflows/script_pep8check.yml
@@ -16,7 +16,7 @@ jobs:
     ## routine to gather only the changed python files and supply them to the matrix
     - name: changed-files
       id: get-changed-files
-      uses: tj-actions/changed-files@v26.1
+      uses: tj-actions/changed-files@v41.0.1
       with:
         separator: ","
         files: |


### PR DESCRIPTION
This PR addresses potential code vulnerablities identified in dependabot alerts [1](https://github.com/spacetelescope/notebook-ci-actions/security/dependabot/1), [2](https://github.com/spacetelescope/notebook-ci-actions/security/dependabot/2), [3](https://github.com/spacetelescope/notebook-ci-actions/security/dependabot/3), and [4](https://github.com/spacetelescope/notebook-ci-actions/security/dependabot/4). 

Updated version of changed-files used from v26.1 to v41.0.1 in the following files:
- ci_runner.yml
- ci_validation.yml
- notebook_pep8check.yml
- script_pep8check.yml