### PR TITLE
Bugfix: update pep8 checker scripts to ignore jupyter notebook code block lines starting with a "!" when the only line ignored is in a loop

### DIFF
--- a/.github/helpers/pep8_nb_style_checker.py
+++ b/.github/helpers/pep8_nb_style_checker.py
@@ -104,7 +104,7 @@ def nb_style_checker(nb_file):
                                     else '  # noqa' + top_line[noqa_check.end():])
 
                     for ln in cl['source']:
-                        # replace lines with IPython magic commands with a "pass" statements
+                        # replace lines with IPython magic commands with a "pass" statement
                         if len(ln.strip()) == 0:
                             line = ln
                         else:

--- a/.github/helpers/pep8_nb_style_checker.py
+++ b/.github/helpers/pep8_nb_style_checker.py
@@ -104,11 +104,11 @@ def nb_style_checker(nb_file):
                                     else '  # noqa' + top_line[noqa_check.end():])
 
                     for ln in cl['source']:
-                        # comment out lines with IPython magic commands
+                        # replace lines with IPython magic commands with a "pass" statements
                         if len(ln.strip()) == 0:
                             line = ln
                         else:
-                            line = ln if ln.strip()[0] not in ["!", "%"] else '# ' + ln
+                            line = ln if ln.strip()[0] not in ["!", "%"] else ln.replace(ln.strip(), "pass")
 
                         # insert noqa comment if needed (with care for newline char)
                         if (noqa_comment and not line.startswith('#')


### PR DESCRIPTION
**Relevant JIRA Ticket**
- [SPB-1765](https://jira.stsci.edu/browse/SPB-1765)

**Summary**
In Jupyter Notebook syntax, lines of code in imbedded code blocks starting with an excitation point are interpreted as commands to be executed by the shell (command line), rather than in Python.

As it stands, the pep8 checker simply ignores these lines by commenting them out. The problem is that when such a line is the only line of code in a 'for' loop, it then results in a "E999 IndentationError" on the next line when flake8 is run

**Solution:**

instead of simply commenting out code lines starting with a "!" or "%" character, the placeholder command "pass" is to be inserted in place of the whole line. This will ensure loop integrity. 