### PR TITLE
Enhance CI scheduled to prioritize prerequirements.txt for dependency…

### DIFF
--- a/.github/workflows/ci_scheduled.yml
+++ b/.github/workflows/ci_scheduled.yml
@@ -63,6 +63,9 @@ jobs:
             chmod +x $(dirname "${{ matrix.notebooks }}")/pre-requirements.sh
             ./$(dirname "${{ matrix.notebooks }}")/pre-requirements.sh
           fi
+          if [ -f $(dirname "${{ matrix.notebooks }}")/pre-requirements.txt ]; then
+            pip install -r $(dirname  "${{ matrix.notebooks }}")/pre-requirements.txt
+          fi
           if [ -f pre-requirements.txt ]; then
             pip install -r pre-requirements.txt
           fi


### PR DESCRIPTION
Currently, a notebook is failing during weekly execution, but it passes when ci_runner is run. This is due to incomplete dependency installation, where it misses the pre-requirements.txt file. Therefore, this PR adds that missing logic to the ci_scheduled.yml file.