### PR TITLE
Restrict JupyterBook validation to PR mode only

### DIFF
--- a/.github/workflows/notebook-ci-unified.yml
+++ b/.github/workflows/notebook-ci-unified.yml
@@ -703,6 +703,7 @@ jobs:
     needs: setup-matrix
     if: |
       needs.setup-matrix.outputs.matrix-notebooks != '[]' &&
+      inputs.execution-mode == 'pr' &&
       (inputs.enable-validation == true || inputs.trigger-event == 'all' || inputs.trigger-event == 'validate')
     runs-on: ubuntu-24.04
     strategy:
@@ -785,7 +786,7 @@ jobs:
 
   # Main Notebook Processing
   process-notebooks:
-    needs: [setup-matrix, validate-jupyter-book]
+    needs: setup-matrix
     # environment: ci_env  # Temporarily removed to test runner assignment
     if: |
       needs.setup-matrix.outputs.skip-execution != 'true' && 


### PR DESCRIPTION
- JupyterBook validation now only runs during PR workflow
- Removes dependency on validate-jupyter-book for process-notebooks job
- Allows full-pipeline-all to execute notebooks without waiting for validation
- Validation still available for PR review and merge protection