### PR TITLE
Expose CRDS variables as optional caller workflow inputs

### DIFF
--- a/.github/workflows/notebook-ci-unified.yml
+++ b/.github/workflows/notebook-ci-unified.yml
@@ -45,6 +45,23 @@ on:
         description: 'Path to custom requirements file'
         required: false
         type: string
+
+      # Optional CRDS Configuration (for JWST-style pipelines)
+      crds-server-url:
+        description: 'Optional CRDS server URL (sets CRDS_SERVER_URL)'
+        required: false
+        type: string
+        default: ''
+      crds-context:
+        description: 'Optional CRDS context (sets CRDS_CONTEXT)'
+        required: false
+        type: string
+        default: ''
+      crds-path:
+        description: 'Optional CRDS cache path (sets CRDS_PATH)'
+        required: false
+        type: string
+        default: ''
       
       # Notebook Selection
       single-notebook:
@@ -109,6 +126,13 @@ on:
         required: false
       CASJOBS_PW:
         required: false
+
+env:
+  # Optional CRDS configuration exposed to all jobs. These are typically used by
+  # JWST-style pipelines; callers can omit them entirely if not needed.
+  CRDS_SERVER_URL: ${{ inputs.crds-server-url }}
+  CRDS_CONTEXT: ${{ inputs.crds-context }}
+  CRDS_PATH: ${{ inputs.crds-path }}
 
 jobs:
   # Change Detection and Matrix Setup

--- a/README.md
+++ b/README.md
@@ -137,6 +137,25 @@ with:
   deprecation-days: 30              # Days until deprecation expires
 ```
 
+### Optional CRDS Configuration (JWST-style Pipelines)
+
+Some notebook repositories (for example, JWST/CRDS consumers) need CRDS
+environment variables to be set during notebook execution. Because callers
+cannot pass `env` directly to a reusable workflow, the unified workflow
+exposes these as optional inputs:
+
+```yaml
+with:
+  # Optional CRDS options (all default to empty strings)
+  crds-server-url: 'https://jwst-crds.stsci.edu'   # -> CRDS_SERVER_URL
+  crds-context: 'jwst_1234.pmap'                   # -> CRDS_CONTEXT
+  crds-path: '/tmp/crds_cache'                     # -> CRDS_PATH
+```
+
+When provided, these inputs are mapped to `CRDS_SERVER_URL`, `CRDS_CONTEXT`,
+and `CRDS_PATH` at the workflow level so that all jobs see the same CRDS
+configuration. If you do not need CRDS, simply omit these inputs.
+
 ## 🛠️ Common Use Cases
 
 ### 1. Pull Request Validation

--- a/examples/workflows/notebook-ci-on-demand.yml
+++ b/examples/workflows/notebook-ci-on-demand.yml
@@ -58,6 +58,21 @@ on:
         required: false
         default: ''
         type: string
+      crds-server-url:
+        description: 'Optional CRDS server URL (sets CRDS_SERVER_URL)'
+        required: false
+        default: ''
+        type: string
+      crds-context:
+        description: 'Optional CRDS context (sets CRDS_CONTEXT)'
+        required: false
+        default: ''
+        type: string
+      crds-path:
+        description: 'Optional CRDS cache path (sets CRDS_PATH)'
+        required: false
+        default: ''
+        type: string
 
 jobs:
   on-demand-ci:
@@ -74,6 +89,10 @@ jobs:
       enable-html-build: ${{ inputs.build-documentation }}
       skip-deprecated: ${{ inputs.skip-deprecated }}
       post-run-script: ${{ inputs.post-processing }}
+      # Optional CRDS configuration for JWST-style pipelines
+      crds-server-url: ${{ inputs.crds-server-url }}
+      crds-context: ${{ inputs.crds-context }}
+      crds-path: ${{ inputs.crds-path }}
     secrets:
       CASJOBS_USERID: ${{ secrets.CASJOBS_USERID }}
       CASJOBS_PW: ${{ secrets.CASJOBS_PW }}


### PR DESCRIPTION
### Optional CRDS Configuration (JWST-style Pipelines)

Some notebook repositories (for example, JWST/CRDS consumers) need CRDS
environment variables to be set during notebook execution. Because callers
cannot pass `env` directly to a reusable workflow, the unified workflow
exposes these as optional inputs:

```yaml
with:
  # Optional CRDS options (all default to empty strings)
  crds-server-url: 'https://jwst-crds.stsci.edu'   # -> CRDS_SERVER_URL
  crds-context: 'jwst_1234.pmap'                   # -> CRDS_CONTEXT
  crds-path: '/tmp/crds_cache'                     # -> CRDS_PATH
```

When provided, these inputs are mapped to `CRDS_SERVER_URL`, `CRDS_CONTEXT`,
and `CRDS_PATH` at the workflow level so that all jobs see the same CRDS
configuration. If you do not need CRDS, simply omit these inputs.