### PR TITLE
Adding in option for 'pre-script' to run scripts before notebook operations

### DIFF
--- a/.github/workflows/notebook-ci-unified.yml
+++ b/.github/workflows/notebook-ci-unified.yml
@@ -106,6 +106,12 @@ on:
         description: 'Optional post-processing script path'
         required: false
         type: string
+
+      # Pre-processing
+      pre-processing-script:
+        description: 'Optional pre-processing script path (runs before validation/execution)'
+        required: false
+        type: string
       
       # Deprecation
       deprecation-days:
@@ -902,6 +908,27 @@ jobs:
             pip install -r "$nb_dir/requirements.txt"
           else
             echo "No requirements.txt found in $nb_dir - using base environment only"
+          fi
+
+      - name: Run pre-processing script
+        if: inputs.pre-processing-script != ''
+        run: |
+          notebook="${{ matrix.notebook }}"
+          nb_dir=$(dirname "$notebook")
+
+          eval "$(micromamba shell hook --shell bash)"
+          micromamba activate ci-env
+
+          script_path="${{ inputs.pre-processing-script }}"
+
+          if [ -f "$script_path" ]; then
+            echo "🔧 Running pre-processing script: $script_path"
+            python "$script_path"
+          elif [ -f "$nb_dir/$script_path" ]; then
+            echo "🔧 Running notebook-local pre-processing script: $nb_dir/$script_path"
+            python "$nb_dir/$script_path"
+          else
+            echo "ℹ️ Pre-processing script not found at repo or notebook level; skipping."
           fi
 
       - name: Validate notebook

--- a/README.md
+++ b/README.md
@@ -135,6 +135,9 @@ with:
   
   # Deprecation management
   deprecation-days: 30              # Days until deprecation expires
+
+  # Optional pre-processing hook
+  pre-processing-script: 'scripts/notebook_data_dependencies.py'  # Runs before validation/execution
 ```
 
 ### Optional CRDS Configuration (JWST-style Pipelines)


### PR DESCRIPTION
**Summary**

Introduce an optional pre-processing-script input to the unified reusable workflow that runs a Python helper script before validation/execution in the same ci-env.
Add optional CRDS-related inputs (crds-server-url, crds-context, crds-path) and expose them as CRDS_SERVER_URL, CRDS_CONTEXT, and CRDS_PATH to all jobs.
Update documentation and example workflows to show how to use both the CRDS configuration and the pre-processing hook.
Details

notebook-ci-unified.yml:

**New inputs:**
pre-processing-script: optional script path that runs after environment setup and requirements installation, but before validation/security/execution.
crds-server-url, crds-context, crds-path: all optional, default to empty strings.

**New behavior:**
pre-processing-script is executed in ci-env once per notebook:
First tries the path relative to the repo root.
Then tries relative to the notebook directory.
If not found in either location, it logs an informational message and skips without failing the job.
CRDS inputs are mapped to workflow-level environment variables:
CRDS_SERVER_URL: ${{ inputs.crds-server-url }}
CRDS_CONTEXT: ${{ inputs.crds-context }}
CRDS_PATH: ${{ inputs.crds-path }}

**Documentation & examples:**
README.md:
Document the new CRDS inputs and how they map to CRDS_* env vars for JWST/CRDS-style pipelines.
Document pre-processing-script, including an example using scripts/notebook_data_dependencies.py.

notebook-ci-on-demand.yml:
Add crds-server-url, crds-context, and crds-path as optional workflow_dispatch inputs.
Pass these through to the unified workflow in the with: block so users can configure CRDS from the on-demand example.

**Motivation / Use cases**

Some notebook suites (e.g. JWST/CRDS consumers) require CRDS configuration via environment variables. Exposing these as typed inputs allows callers to configure CRDS without custom wrappers or relying on forbidden env: on uses steps.
Many repositories need a lightweight hook to download data, set environment variables, or perform per-notebook setup before validation/execution without changing the workflow internals. The new pre-processing-script input provides a simple, optional way to do that, supporting both shared scripts (e.g. shared/notebook_data_dependencies.py) and per-notebook-directory helpers.

**Backward compatibility**

All new inputs are optional with safe defaults:
If pre-processing-script is not set, the new step is skipped entirely and behavior is unchanged.
If CRDS inputs are not set, the corresponding CRDS_* environment variables are empty and do not affect existing callers.
Existing workflows that do not use these inputs continue to function exactly as before.